### PR TITLE
Redirect from / to /1.2/ using javascript

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to Latest version</title>
+  </head>
+  <body>
+    <script>
+      window.location.replace("1.2" + window.location.hash);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This will redirect visitors from https://kba.github.io/hocr-spec to https://kba.github.io/hocr-spec/1.2/ and even from https://kba.github.io/hocr-spec#bbox to https://kba.github.io/hocr-spec/1.2/#bbox.

HTTP redirects are too much hassle with Github Pages.
