### PR TITLE
Fix MathML/CML flip

### DIFF
--- a/1.2/index.html
+++ b/1.2/index.html
@@ -1424,7 +1424,7 @@ Possible extra rowspan handling
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">hOCR - OCR Workflow and Output embedded in HTML</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2017-04-24">24 April 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2017-07-19">19 July 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1444,7 +1444,7 @@ Possible extra rowspan handling
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 24 April 2017,
+In addition, as of 19 July 2017,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -2350,8 +2350,8 @@ the corresponding text</p>
    </dl>
    <p>Mathematical and chemical formulas that float must be put into an <code><a data-link-type="element" href="#elementdef-ocr_float" id="ref-for-elementdef-ocr_float-2">ocr_float</a></code> section. Formulas that are “display” mode should be put into
 an <code><a data-link-type="element" href="#elementdef-ocr_display" id="ref-for-elementdef-ocr_display-3">ocr_display</a></code> section. <code><a data-link-type="element" href="#elementdef-ocr_math" id="ref-for-elementdef-ocr_math-2">ocr_math</a></code> and <code><a data-link-type="element" href="#elementdef-ocr_chem" id="ref-for-elementdef-ocr_chem-2">ocr_chem</a></code></p>
-   <p><code><a data-link-type="element" href="#elementdef-ocr_math" id="ref-for-elementdef-ocr_math-3">ocr_math</a></code> must either be or contain either a single <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code> tag or <a data-link-type="biblio" href="#biblio-cml">[CML]</a> markup</p>
-   <p><code><a data-link-type="element" href="#elementdef-ocr_chem" id="ref-for-elementdef-ocr_chem-3">ocr_chem</a></code> must either be or contain either a single <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code> tag or <a data-link-type="biblio" href="#biblio-mathml">[MathML]</a> markup</p>
+   <p><code><a data-link-type="element" href="#elementdef-ocr_math" id="ref-for-elementdef-ocr_math-3">ocr_math</a></code> must either be or contain either a single <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code> tag or <a data-link-type="biblio" href="#biblio-mathml">[MathML]</a> markup</p>
+   <p><code><a data-link-type="element" href="#elementdef-ocr_chem" id="ref-for-elementdef-ocr_chem-3">ocr_chem</a></code> must either be or contain either a single <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code> tag or <a data-link-type="biblio" href="#biblio-cml">[CML]</a> markup</p>
    <h4 class="heading settled" data-level="3.4.4" id="sec-ocr_cinfo"><span class="secno">3.4.4. </span><span class="content">Unspecified inline content: <dfn class="dfn-paneled" data-dfn-type="element" data-export="" id="elementdef-ocr_cinfo">ocr_cinfo</dfn></span><a class="self-link" href="#sec-ocr_cinfo"></a></h4>
    <p class="issue" id="issue-d9f7da0d"><a class="self-link" href="#issue-d9f7da0d"></a> Define <dfn class="dfn-paneled" data-dfn-type="element" data-export="" id="elementdef-ocrx_cinfo">ocrx_cinfo</dfn></p>
    <ul>

--- a/1.2/spec.before.html
+++ b/1.2/spec.before.html
@@ -22,8 +22,8 @@ spec:html;type:element;
 </pre>
 
 <pre class="anchors">
-spec:html40;text:font;type:element;url:https://www.w3.org/TR/html401/present/graphics.html#edef-FONT
-spec:html40;text:nobr;type:element;urlPrefix:https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nobr
+spec:html401;text:font;type:element;url:https://www.w3.org/TR/html401/present/graphics.html#edef-FONT
+spec:html401;text:nobr;type:element;urlPrefix:https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nobr
 spec:html;type:element;url:https://www.w3.org/TR/html5/text-level-semantics.html#the-sub-and-sup-elements
 	text:sub
 	text:sup

--- a/1.2/spec.md
+++ b/1.2/spec.md
@@ -486,9 +486,9 @@ Mathematical and chemical formulas that float must be put into an <{ocr_float}>
 section. Formulas that are “display” mode should be put into
 an <{ocr_display}> section. <{ocr_math}> and <{ocr_chem}>
 
-<{ocr_math}> must either be or contain either a single <{img}> tag or [[CML]] markup
+<{ocr_math}> must either be or contain either a single <{img}> tag or [[MathML]] markup
 
-<{ocr_chem}> must either be or contain either a single <{img}> tag or [[MathML]] markup
+<{ocr_chem}> must either be or contain either a single <{img}> tag or [[CML]] markup
 
 ### Unspecified inline content: <dfn element>ocr_cinfo</dfn> ### {#sec-ocr_cinfo}
 


### PR DESCRIPTION
Currently the descriptions for ocr_math and ocr_chem are flipped.