### PR TITLE
Add note on ocrx_line by @tmbdev

### DIFF
--- a/1.2/index.html
+++ b/1.2/index.html
@@ -418,7 +418,7 @@
 	[data-algorithm]:not(.heading) {
 	  padding: .5em;
 	  border: thin solid #ddd; border-radius: .5em;
-	  margin: .5em calc(-0.5em - 1px);
+	  margin: .5em 0;
 	}
 	[data-algorithm]:not(.heading) > :first-child {
 	  margin-top: 0;
@@ -1176,8 +1176,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version a60ced33ed990d75e39d2ba357c10dd3c8679190" name="generator">
-  <link href="http://kba.github.io/hocr-spec/1.2/" rel="canonical">
+  <meta content="Bikeshed 1.0.0" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1424,7 +1423,7 @@ Possible extra rowspan handling
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">hOCR - OCR Workflow and Output embedded in HTML</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2017-07-19">19 July 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2017-11-30">30 November 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1444,14 +1443,14 @@ Possible extra rowspan handling
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 19 July 2017,
+In addition, as of 30 November 2017,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
    <hr title="Separator for header">
   </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
   <div class="p-summary" data-fill-with="abstract">
-   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
    <p>The purpose of this document is to define an open standard for representing document layout analysis and OCR results as a subset of HTML.</p>
   </div>
   <div data-fill-with="at-risk"></div>
@@ -1655,7 +1654,7 @@ and attributes inside HTML. We are going to use the terms <a data-link-type="dfn
    <p>An hOCR element (in this spec simply refered to as an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="element">element</dfn>) is any HTML tag with a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/dom.html#classes">class</a></code> attribute that contains exactly one <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Element Name" data-noexport="" id="element-name">class
 name</dfn> that starts with <code>ocr_</code> or <code>ocrx_</code>. Non-OCR related HTML content must
 not use class names that begin with <code>ocr_</code> or <code>ocrx_</code>.</p>
-   <p class="note" role="note"><span>Note:</span> When referring to an HTML tag with class <code>ocr_page</code>, this spec uses the
+   <p class="note" role="note">Note: When referring to an HTML tag with class <code>ocr_page</code>, this spec uses the
 notation <code><a data-link-type="element" href="#elementdef-ocr_page" id="ref-for-elementdef-ocr_page-2">ocr_page</a></code></p>
    <p>If an HTML tag is an <a data-link-type="dfn" href="#element" id="ref-for-element-2">hOCR element</a>, then its <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute">title</a></code> attribute must not be used for any other purpose than to define <a data-link-type="dfn" href="#properties" id="ref-for-properties-2">hOCR properties</a> and adhere to the <a data-link-type="dfn" href="#properties-format" id="ref-for-properties-format-1">properties format</a>.</p>
    <p>For some elements, the specs <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Recommended HTML Tag" data-noexport="" id="recommended-html-tag">recommends using
@@ -1666,7 +1665,7 @@ an existing HTML output routine).</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="properties" data-noexport="" id="properties">hOCR Properties</dfn> are a set of key-value pairs that convey OCR-specific
 information related to specific <a data-link-type="dfn" href="#element" id="ref-for-element-3">elements</a>. They are serialized using a <a data-link-type="dfn" href="#properties-format" id="ref-for-properties-format-2">specific format</a> in the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute">title</a></code> attribute of
 the <a data-link-type="dfn" href="#element" id="ref-for-element-4">element</a> they refer to.</p>
-   <p class="note" role="note"><span>Note:</span> When referring to a property <code>bbox</code>, this spec uses the notation <a class="property" data-link-type="propdesc" href="#propdef-bbox" id="ref-for-propdef-bbox-1">bbox</a>.</p>
+   <p class="note" role="note">Note: When referring to a property <code>bbox</code>, this spec uses the notation <a class="property" data-link-type="propdesc" href="#propdef-bbox" id="ref-for-propdef-bbox-1">bbox</a>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Property Name" data-noexport="" id="property-name">name of a property</dfn> must only consist of
 lowercase letters and numbers. Property names must be either from those defined
 in <a href="#hocr-props">§4 The properties of hOCR</a> or begin with <code>x_</code> to denote implementation-specific
@@ -1680,24 +1679,28 @@ as a <dfn data-dfn-type="dfn" data-noexport="" id="capability">capability<a clas
 hOCR consumers that they may encounter those elements/properties. If a producer
 is <strong>not capable</strong> of producing certain elements/properties, consumers need not
 look for them.</p>
-   <p class="note" role="note"><span>Note:</span> When referring to a capability <code>ocrp_poly</code>, this spec uses the notation <a class="css" data-link-type="maybe" href="#valdef-ocr-capabilities-ocrp_poly" id="ref-for-valdef-ocr-capabilities-ocrp_poly-1">ocrp_poly</a>.</p>
+   <p class="note" role="note">Note: When referring to a capability <code>ocrp_poly</code>, this spec uses the notation <a class="css" data-link-type="maybe" href="#valdef-ocr-capabilities-ocrp_poly" id="ref-for-valdef-ocr-capabilities-ocrp_poly-1">ocrp_poly</a>.</p>
    <p>The mechanism for declaring capabilities are described in <a href="#capabilities">§6.2 Capabilities</a></p>
    <h3 class="heading settled" data-level="2.3" id="relations"><span class="secno">2.3. </span><span class="content">Relationship between elements, properties</span><a class="self-link" href="#relations"></a></h3>
    <h4 class="heading settled" data-level="2.3.1" id="rel-elem-prop"><span class="secno">2.3.1. </span><span class="content">element - property</span><a class="self-link" href="#rel-elem-prop"></a></h4>
    <p>There are four levels of association between any <a data-link-type="dfn" href="#element" id="ref-for-element-6">element</a> to any <a data-link-type="dfn" href="#properties" id="ref-for-properties-4">property</a>:</p>
    <dl>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="disallowed-property">Disallowed Property</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="disallowed-property">Disallowed Property</dfn></p>
     <dd data-md="">
      <p>The element MUST NOT contain the property</p>
     <dd data-md="">
      <p>Unless defined otherwise, all properties are disallowed for any element.</p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="required-property">Required Property</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="required-property">Required Property</dfn></p>
     <dd data-md="">
      <p>The element MUST contain the property</p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="recommended-property">Recommended Property</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="recommended-property">Recommended Property</dfn></p>
     <dd data-md="">
      <p>The element SHOULD contain the property</p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="allowed-property">Allowed Property</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="allowed-property">Allowed Property</dfn></p>
     <dd data-md="">
      <p>The element MAY contain the property</p>
    </dl>
@@ -1705,18 +1708,22 @@ look for them.</p>
    <p>A property present on an element can have on of the following relations to any
 other property:</p>
    <dl>
-    <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="independent-property">Independent Property<a class="self-link" href="#independent-property"></a></dfn>
+    <dt data-md="">
+     <p><dfn data-dfn-type="dfn" data-noexport="" id="independent-property">Independent Property<a class="self-link" href="#independent-property"></a></dfn></p>
     <dd data-md="">
      <p>The presence of property A has no influence on the presence of property B</p>
     <dd data-md="">
      <p>Unless otherwise defiined, properties are always independent</p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="implied-property">Implied Property</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="implied-property">Implied Property</dfn></p>
     <dd data-md="">
      <p>If property A is present, property B must also be present</p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="conflicting-property">Conflicting Property</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="conflicting-property">Conflicting Property</dfn></p>
     <dd data-md="">
      <p>If property A is present, property B must not be present</p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="related-property">Related Property</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="related-property">Related Property</dfn></p>
     <dd data-md="">
      <p>Property B is related to property A</p>
    </dl>
@@ -1766,30 +1773,35 @@ the exact <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="prop
    <h2 class="heading settled" data-level="3" id="hocr-elements"><span class="secno">3. </span><span class="content">The elements of hOCR</span><a class="self-link" href="#hocr-elements"></a></h2>
    <p>The <a data-link-type="dfn" href="#element" id="ref-for-element-7">elements</a> in hOCR can be broadly <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Element Categories" data-noexport="" id="element-categories">categorized</dfn> as follows:</p>
    <dl>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="typesetting-elements">Typesetting Elements</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="typesetting-elements">Typesetting Elements</dfn></p>
     <dd data-md="">
      <p>Elements that describe those areas of a page that nest but don’t generally
 overlap</p>
     <dd data-md="">
      <p>See <a href="#sec-typesetting-elements">§3.1 Typesetting Elements</a></p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="float-elements">Float Elements</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="float-elements">Float Elements</dfn></p>
     <dd data-md="">
      <p>Elements that describe those areas of a page that are not part of the flow
 but are positioned</p>
     <dd data-md="">
      <p>See <a href="#sec-float-elements">§3.2 Float elements</a></p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="logical-elements">Logical Elements</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="logical-elements">Logical Elements</dfn></p>
     <dd data-md="">
      <p>These elements describe a page and its components in traditional
 typesetting.</p>
     <dd data-md="">
      <p>See <a href="#sec-logical-elements">§3.3 Logical Elements</a></p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="inline-elements">Inline elements</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="inline-elements">Inline elements</dfn></p>
     <dd data-md="">
      <p>Thse elements describe content beyond the level of text lines</p>
     <dd data-md="">
      <p>See <a href="#sec-inline-elements">§3.4 Inline Elements</a></p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="engine-specific-elements">Engine-Specific elements</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="engine-specific-elements">Engine-Specific elements</dfn></p>
     <dd data-md="">
      <p>Elements whose semantics are engine-specific</p>
     <dd data-md="">
@@ -2400,7 +2412,6 @@ existing OCR output, say for workflow abstractions.</p>
     <dt><a data-link-type="dfn" href="#element-categories" id="ref-for-element-categories-37">Categories</a>
     <dd><a data-link-type="dfn" href="#inline-elements" id="ref-for-inline-elements-6">Inline Elements</a> , <a data-link-type="dfn" href="#engine-specific-elements" id="ref-for-engine-specific-elements-2">Engine-Specific Elements</a> 
    </dl>
-   <p class="issue" id="issue-8ef34561"><a class="self-link" href="#issue-8ef34561"></a> <a href="https://github.com/kba/hocr-spec/issues/19">ocr_line vs ocrx_line</a></p>
    <ul>
     <li data-md="">
      <p>any kind of "line" returned by an OCR system that differs from the standard <code><a data-link-type="element" href="#elementdef-ocr_line" id="ref-for-elementdef-ocr_line-4">ocr_line</a></code> above</p>
@@ -2409,6 +2420,18 @@ existing OCR output, say for workflow abstractions.</p>
     <li data-md="">
      <p>an <code><a data-link-type="element" href="#elementdef-ocrx_line" id="ref-for-elementdef-ocrx_line-3">ocrx_line</a></code> should correspond as closely as possible to an <code><a data-link-type="element" href="#elementdef-ocr_line" id="ref-for-elementdef-ocr_line-5">ocr_line</a></code></p>
    </ul>
+   <div class="note" role="note">
+    <p><code><a data-link-type="element" href="#elementdef-ocrx_line" id="ref-for-elementdef-ocrx_line-4">ocrx_line</a></code> is engine-specific line markup. It exists for those cases where
+your OCR engine outputs text lines that don’t correspond to "normal" text lines.</p>
+    <p>The most common case is if you apply an engine that is not capable of column
+segmentation to a multi-column document and you want to prevent subsequent
+processing stages from assuming that the text lines it gets contain text in
+reading order.</p>
+    <p>Basically, if you use <code><a data-link-type="element" href="#elementdef-ocrx_line" id="ref-for-elementdef-ocrx_line-5">ocrx_line</a></code> instead of <code><a data-link-type="element" href="#elementdef-ocr_line" id="ref-for-elementdef-ocr_line-6">ocr_line</a></code>, you’re
+(intentionally) breaking most subsequent processing, since most OCR output
+processing will look for <code><a data-link-type="element" href="#elementdef-ocr_line" id="ref-for-elementdef-ocr_line-7">ocr_line</a></code> tags (and assume they are in reading
+order).</p>
+   </div>
    <h4 class="heading settled" data-level="3.5.3" id="sec-ocrx_word"><span class="secno">3.5.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="element" data-export="" id="elementdef-ocrx_word">ocrx_word</dfn></span><a class="self-link" href="#sec-ocrx_word"></a></h4>
    <dl class="def">
     <dt><a data-link-type="dfn" href="#element-name" id="ref-for-element-name-38">Name</a>
@@ -2426,50 +2449,64 @@ existing OCR output, say for workflow abstractions.</p>
    <p>The <a data-link-type="dfn" href="#properties" id="ref-for-properties-6">properties</a> in hOCR can be broadly <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Property
 Categories" data-noexport="" id="property-categories">categorized</dfn> as follows:</p>
    <dl>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="general-properties">General Properties</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="general-properties">General Properties</dfn></p>
     <dd data-md="">
      <p>These properties can apply to most elements</p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="non-recommended-properties">Non-Recommended Properties</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="non-recommended-properties">Non-Recommended Properties</dfn></p>
     <dd data-md="">
      <p>These properties can apply to most elements but should not be used unless
 there is no alternative:</p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="inline-properties">Inline Properties</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="inline-properties">Inline Properties</dfn></p>
     <dd data-md="">
-     <p>These properties apply to content on or below the level of <code><a data-link-type="element" href="#elementdef-ocr_line" id="ref-for-elementdef-ocr_line-6">ocr_line</a></code> / <code><a data-link-type="element" href="#elementdef-ocrx_line" id="ref-for-elementdef-ocrx_line-4">ocrx_line</a></code></p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="layout-properties">Layout Properties</dfn>
+     <p>These properties apply to content on or below the level of <code><a data-link-type="element" href="#elementdef-ocr_line" id="ref-for-elementdef-ocr_line-8">ocr_line</a></code> / <code><a data-link-type="element" href="#elementdef-ocrx_line" id="ref-for-elementdef-ocrx_line-6">ocrx_line</a></code></p>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="layout-properties">Layout Properties</dfn></p>
     <dd data-md="">
      <p>These properties relate to placement of <a data-link-type="dfn" href="#element" id="ref-for-element-8">elements</a> on the page</p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="font-properties">Font Properties</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="font-properties">Font Properties</dfn></p>
     <dd data-md="">
      <p>These properties convey font information</p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="character-properties">Character Properties</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="character-properties">Character Properties</dfn></p>
     <dd data-md="">
      <p>These properties convey character level information</p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="page-properties">Page Properties</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="page-properties">Page Properties</dfn></p>
     <dd data-md="">
      <p>These properties convey information on the whole page</p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="content-flow-properties">Content Flow Properties</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="content-flow-properties">Content Flow Properties</dfn></p>
     <dd data-md="">
      <p>These properties are related to the reading order and flow of content on the page</p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="confidence-properties">Confidence Properties</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="confidence-properties">Confidence Properties</dfn></p>
     <dd data-md="">
      <p>These properties are related to the confidence of the hOCR producer that
 the text in the <a data-link-type="dfn" href="#element" id="ref-for-element-9">element</a> has been correctly recognized</p>
    </dl>
    <h3 class="heading settled" data-level="4.1" id="baseline"><span class="secno">4.1. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-baseline">baseline</dfn> property</span><a class="self-link" href="#baseline"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-1">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-1">Name</a></p>
     <dd data-md="">
      <p>baseline</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-1">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-1">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#inline-properties" id="ref-for-inline-properties-1">Inline</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-1">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-1">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-3">property-name</a> = "baseline"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-3">property-value</a> = <a data-link-type="grammar" href="#grammardef-float" id="ref-for-grammardef-float-1">float</a> <a data-link-type="grammar" href="#grammardef-int" id="ref-for-grammardef-int-1">int</a>
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">baseline</span> <span class="mf">0.015</span> <span class="o">-</span><span class="mi">18</span>
 </pre>
@@ -2492,21 +2529,27 @@ left corner of the bounding box (red). The baseline crosses the y-axis at <code>
    </div>
    <h3 class="heading settled" data-level="4.2" id="bbox"><span class="secno">4.2. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-bbox">bbox</dfn> property</span><a class="self-link" href="#bbox"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-2">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-2">Name</a></p>
     <dd data-md="">
      <p>bbox</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-2">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-2">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#general-properties" id="ref-for-general-properties-1">General</a>, <a data-link-type="dfn" href="#layout-properties" id="ref-for-layout-properties-1">Layout</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#conflicting-property" id="ref-for-conflicting-property-1">Conflicting</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#conflicting-property" id="ref-for-conflicting-property-1">Conflicting</a></p>
     <dd data-md="">
      <p><a class="css" data-link-type="property" href="#propdef-poly" id="ref-for-propdef-poly-2">poly</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-2">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-2">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-4">property-name</a> = "bbox"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-4">property-value</a> = <a data-link-type="grammar" href="#grammardef-uint" id="ref-for-grammardef-uint-5">uint</a> <a data-link-type="grammar" href="#grammardef-uint" id="ref-for-grammardef-uint-6">uint</a> <a data-link-type="grammar" href="#grammardef-uint" id="ref-for-grammardef-uint-7">uint</a> <a data-link-type="grammar" href="#grammardef-uint" id="ref-for-grammardef-uint-8">uint</a>
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">bbox</span> <span class="mi">0</span> <span class="mi">0</span> <span class="mi">100</span> <span class="mi">200</span>
 </pre>
@@ -2542,18 +2585,23 @@ the document image which border is drawn in black.</p>
    </div>
    <h3 class="heading settled" data-level="4.3" id="cflow"><span class="secno">4.3. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-cflow">cflow</dfn> property</span><a class="self-link" href="#cflow"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-3">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-3">Name</a></p>
     <dd data-md="">
      <p>cflow</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-3">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-3">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#content-flow-properties" id="ref-for-content-flow-properties-1">Content Flow</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-3">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-3">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-5">property-name</a> = "cflow"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-5">property-value</a> = <a data-link-type="grammar" href="#grammardef-delimited-string" id="ref-for-grammardef-delimited-string-3">delimited-string</a>
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">cflow</span> <span class="s">"</span><span class="s">article1</span><span class="s">"</span>
 </pre>
@@ -2572,24 +2620,31 @@ order is attempted and multiple content flows are present</p>
    </ul>
    <h3 class="heading settled" data-level="4.4" id="cuts"><span class="secno">4.4. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-cuts">cuts</dfn> property</span><a class="self-link" href="#cuts"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-4">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-4">Name</a></p>
     <dd data-md="">
      <p>cuts</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-4">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-4">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#layout-properties" id="ref-for-layout-properties-2">Layout</a>, <a data-link-type="dfn" href="#character-properties" id="ref-for-character-properties-1">Character</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-1">Related</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-1">Related</a></p>
     <dd data-md="">
      <p><a class="css" data-link-type="property" href="#propdef-nlp" id="ref-for-propdef-nlp-2">nlp</a>, <a class="css" data-link-type="property" href="#propdef-x_bboxes" id="ref-for-propdef-x_bboxes-5">x_bboxes</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#implied-property" id="ref-for-implied-property-1">Implied</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#implied-property" id="ref-for-implied-property-1">Implied</a></p>
     <dd data-md="">
      <p><a class="css" data-link-type="property" href="#propdef-bbox" id="ref-for-propdef-bbox-24">bbox</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-4">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-4">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-6">property-name</a> = "cuts"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-6">property-value</a> = +(<a data-link-type="grammar" href="#grammardef-uint" id="ref-for-grammardef-uint-9">uint</a> *1(<a data-link-type="grammar" href="#grammardef-comma" id="ref-for-grammardef-comma-1">comma</a> <a data-link-type="grammar" href="#grammardef-uint" id="ref-for-grammardef-uint-10">uint</a> *1(<a data-link-type="grammar" href="#grammardef-comma" id="ref-for-grammardef-comma-2">comma</a> <a data-link-type="grammar" href="#grammardef-nint" id="ref-for-grammardef-nint-1">nint</a>)))
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">cuts</span> <span class="mi">9</span> <span class="mi">11</span> <span class="mi">7</span><span class="p">,</span><span class="mi">8</span><span class="p">,</span><span class="o">-</span><span class="mi">2</span> <span class="mi">15</span> <span class="mi">3</span>
 </pre>
@@ -2625,18 +2680,23 @@ writing direction is left to right, then rotated back.</p>
 a delta of 0 always corresponds to an invisible codepoint.</p>
    <h3 class="heading settled" data-level="4.5" id="hardbreak"><span class="secno">4.5. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-hardbreak">hardbreak</dfn> property</span><a class="self-link" href="#hardbreak"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-5">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-5">Name</a></p>
     <dd data-md="">
      <p>hardbreak</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-5">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-5">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#inline-properties" id="ref-for-inline-properties-2">Inline</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-5">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-5">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-7">property-name</a> = "hardbreak"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-7">property-value</a> = "0" / "1"
+
 </pre>
-    <dt data-md=""><a data-link-type="dfn" href="#default-value" id="ref-for-default-value-1">Default Value</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#default-value" id="ref-for-default-value-1">Default Value</a></p>
     <dd data-md="">
      <p><code class="highlight" style="display:block;padding: .5em"><span class="n">hardbreak</span> <span class="mi">0</span></code></p>
    </dl>
@@ -2648,26 +2708,32 @@ a delta of 0 always corresponds to an invisible codepoint.</p>
      <p>a one indicates that the line is a hard (explicit) line break</p>
    </ul>
    <p>Any special characters representing the desired end-of-line processing must be
-present inside the <code><a data-link-type="element" href="#elementdef-ocr_line" id="ref-for-elementdef-ocr_line-7">ocr_line</a></code> element. Examples of such special characters are a
+present inside the <code><a data-link-type="element" href="#elementdef-ocr_line" id="ref-for-elementdef-ocr_line-9">ocr_line</a></code> element. Examples of such special characters are a
 soft hyphen ("­", <code>U+00AD</code>), a hard line break (<code>&lt;br></code>), or whitespace (<code></code>) for soft
 line breaks.</p>
    <h3 class="heading settled" data-level="4.6" id="image"><span class="secno">4.6. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-image">image</dfn> property</span><a class="self-link" href="#image"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-6">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-6">Name</a></p>
     <dd data-md="">
      <p>image</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-6">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-6">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#page-properties" id="ref-for-page-properties-1">Page</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-2">Related</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-2">Related</a></p>
     <dd data-md="">
      <p><a class="css" data-link-type="property" href="#propdef-imagemd5" id="ref-for-propdef-imagemd5-3">imagemd5</a>, <a class="css" data-link-type="property" href="#propdef-x_source" id="ref-for-propdef-x_source-3">x_source</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-6">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-6">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-8">property-name</a> = "image"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-8">property-value</a> = <a data-link-type="grammar" href="#grammardef-delimited-string" id="ref-for-grammardef-delimited-string-4">delimited-string</a>
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">image</span> <span class="s">"</span><span class="s">/foo/bar.png</span><span class="s">"</span>
 </pre>
@@ -2688,19 +2754,24 @@ resolve to the corresponding image file</p>
    </ul>
    <h3 class="heading settled" data-level="4.7" id="imagemd5"><span class="secno">4.7. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-imagemd5">imagemd5</dfn> property</span><a class="self-link" href="#imagemd5"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-7">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-7">Name</a></p>
     <dd data-md="">
      <p>imagemd5</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-7">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-7">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#page-properties" id="ref-for-page-properties-2">Page</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#implied-property" id="ref-for-implied-property-2">Implied</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#implied-property" id="ref-for-implied-property-2">Implied</a></p>
     <dd data-md="">
      <p><a class="css" data-link-type="property" href="#propdef-image" id="ref-for-propdef-image-3">image</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-7">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-7">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-9">property-name</a> = "imagemd5"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-9">property-value</a> = <a data-link-type="grammar" href="#grammardef-doublequote" id="ref-for-grammardef-doublequote-4">doublequote</a> 32(%x41-46 / <a data-link-type="grammar" href="#grammardef-digit" id="ref-for-grammardef-digit-3">digit</a>) <a data-link-type="grammar" href="#grammardef-doublequote" id="ref-for-grammardef-doublequote-5">doublequote</a>
+
 </pre>
    </dl>
    <ul>
@@ -2711,21 +2782,27 @@ resolve to the corresponding image file</p>
    </ul>
    <h3 class="heading settled" data-level="4.8" id="lpageno"><span class="secno">4.8. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-lpageno">lpageno</dfn> property</span><a class="self-link" href="#lpageno"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-8">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-8">Name</a></p>
     <dd data-md="">
      <p>lpageno</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-8">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-8">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#page-properties" id="ref-for-page-properties-3">Page</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-3">Related</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-3">Related</a></p>
     <dd data-md="">
      <p><a class="css" data-link-type="property" href="#propdef-ppageno" id="ref-for-propdef-ppageno-3">ppageno</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-8">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-8">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-10">property-name</a> = "lpageno"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-10">property-value</a> = <a data-link-type="grammar" href="#grammardef-delimited-string" id="ref-for-grammardef-delimited-string-5">delimited-string</a> / <a data-link-type="grammar" href="#grammardef-uint" id="ref-for-grammardef-uint-11">uint</a>
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">lpageno</span> <span class="s">"</span><span class="s">IV.</span><span class="s">"</span>
 </pre>
@@ -2742,21 +2819,27 @@ resolve to the corresponding image file</p>
    </ul>
    <h3 class="heading settled" data-level="4.9" id="ppageno"><span class="secno">4.9. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-ppageno">ppageno</dfn> property</span><a class="self-link" href="#ppageno"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-9">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-9">Name</a></p>
     <dd data-md="">
      <p>ppageno</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-9">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-9">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#page-properties" id="ref-for-page-properties-4">Page</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-4">Related</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-4">Related</a></p>
     <dd data-md="">
      <p><a class="css" data-link-type="property" href="#propdef-lpageno" id="ref-for-propdef-lpageno-3">lpageno</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-9">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-9">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-11">property-name</a> = "ppageno"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-11">property-value</a> = <a data-link-type="grammar" href="#grammardef-uint" id="ref-for-grammardef-uint-12">uint</a>
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">lpageno</span> <span class="mi">7</span>
 </pre>
@@ -2775,22 +2858,28 @@ resolve to the corresponding image file</p>
    </ul>
    <h3 class="heading settled" data-level="4.10" id="nlp"><span class="secno">4.10. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-nlp">nlp</dfn> property</span><a class="self-link" href="#nlp"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-10">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-10">Name</a></p>
     <dd data-md="">
      <p>nlp</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-10">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-10">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#confidence-properties" id="ref-for-confidence-properties-1">Confidence</a>, <a data-link-type="dfn" href="#character-properties" id="ref-for-character-properties-2">Character</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-5">Related</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-5">Related</a></p>
     <dd data-md="">
      <p><a class="css" data-link-type="property" href="#propdef-cuts" id="ref-for-propdef-cuts-4">cuts</a>, <a class="css" data-link-type="property" href="#propdef-x_confs" id="ref-for-propdef-x_confs-3">x_confs</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#implied-property" id="ref-for-implied-property-3">Implied</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#implied-property" id="ref-for-implied-property-3">Implied</a></p>
     <dd data-md="">
      <p><a class="css" data-link-type="property" href="#propdef-cuts" id="ref-for-propdef-cuts-5">cuts</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-10">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-10">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-12">property-name</a> = "nlp"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-12">property-value</a> = +<a data-link-type="grammar" href="#grammardef-float" id="ref-for-grammardef-float-2">float</a>
+
 </pre>
    </dl>
    <ul>
@@ -2799,18 +2888,23 @@ resolve to the corresponding image file</p>
    </ul>
    <h3 class="heading settled" data-level="4.11" id="order"><span class="secno">4.11. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-order">order</dfn> property</span><a class="self-link" href="#order"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-11">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-11">Name</a></p>
     <dd data-md="">
      <p>order</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-11">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-11">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#content-flow-properties" id="ref-for-content-flow-properties-2">Content Flow</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-11">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-11">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-13">property-name</a> = "order"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-13">property-value</a> = +<a data-link-type="grammar" href="#grammardef-uint" id="ref-for-grammardef-uint-13">uint</a>
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">order</span> <span class="mi">8</span>
 </pre>
@@ -2826,21 +2920,27 @@ many tools will not be able to deal with content that is not in reading order</p
    </ul>
    <h3 class="heading settled" data-level="4.12" id="poly"><span class="secno">4.12. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-poly">poly</dfn> property</span><a class="self-link" href="#poly"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-12">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-12">Name</a></p>
     <dd data-md="">
      <p>poly</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-12">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-12">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#layout-properties" id="ref-for-layout-properties-3">Layout</a>, <a data-link-type="dfn" href="#non-recommended-properties" id="ref-for-non-recommended-properties-1">Non-recommended</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#conflicting-property" id="ref-for-conflicting-property-2">Conflicting</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#conflicting-property" id="ref-for-conflicting-property-2">Conflicting</a></p>
     <dd data-md="">
      <p><a class="css" data-link-type="property" href="#propdef-bbox" id="ref-for-propdef-bbox-26">bbox</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-12">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-12">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-14">property-name</a> = "poly"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-14">property-value</a> = 2<a data-link-type="grammar" href="#grammardef-uint" id="ref-for-grammardef-uint-14">uint</a> 2<a data-link-type="grammar" href="#grammardef-int" id="ref-for-grammardef-int-2">int</a> *(2<a data-link-type="grammar" href="#grammardef-int" id="ref-for-grammardef-int-3">int</a>)
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">poly</span> <span class="mi">0</span> <span class="mi">0</span> <span class="mi">0</span> <span class="mi">10</span> <span class="mi">10</span> <span class="mi">10</span> <span class="mi">10</span> <span class="mi">20</span> <span class="mi">0</span> <span class="mi">20</span>
 </pre>
@@ -2862,21 +2962,27 @@ layouts is in terms of rectangular content areas and rectangular floats</p>
    </ul>
    <h3 class="heading settled" data-level="4.13" id="scan_res"><span class="secno">4.13. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-scan_res">scan_res</dfn> property</span><a class="self-link" href="#scan_res"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-13">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-13">Name</a></p>
     <dd data-md="">
      <p>scan_res</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-13">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-13">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#page-properties" id="ref-for-page-properties-5">Page</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-6">Related</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-6">Related</a></p>
     <dd data-md="">
      <p><a class="css" data-link-type="property" href="#propdef-x_scanner" id="ref-for-propdef-x_scanner-3">x_scanner</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-13">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-13">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-15">property-name</a> = "scan_res"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-15">property-value</a> = 2(<a data-link-type="grammar" href="#grammardef-uint" id="ref-for-grammardef-uint-15">uint</a>)
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">scan_res</span> <span class="mi">300</span> <span class="mi">300</span>
 </pre>
@@ -2884,18 +2990,23 @@ layouts is in terms of rectangular content areas and rectangular floats</p>
    <p>The scanning resolution in DPI</p>
    <h3 class="heading settled" data-level="4.14" id="textangle"><span class="secno">4.14. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-textangle">textangle</dfn> property</span><a class="self-link" href="#textangle"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-14">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-14">Name</a></p>
     <dd data-md="">
      <p>textangle</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-14">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-14">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#layout-properties" id="ref-for-layout-properties-4">Layout</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-14">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-14">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-16">property-name</a> = "textangle"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-16">property-value</a> = <a data-link-type="grammar" href="#grammardef-float" id="ref-for-grammardef-float-3">float</a>
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">textangle</span> <span class="mf">7.32</span>
 </pre>
@@ -2907,21 +3018,27 @@ bottom to top in Latin script; note that this is different from reading order,
 which should be indicated using standard HTML properties</p>
    <h3 class="heading settled" data-level="4.15" id="x_bboxes"><span class="secno">4.15. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-x_bboxes">x_bboxes</dfn> property</span><a class="self-link" href="#x_bboxes"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-15">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-15">Name</a></p>
     <dd data-md="">
      <p>x_bboxes</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-15">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-15">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#inline-properties" id="ref-for-inline-properties-3">Inline</a>, <a data-link-type="dfn" href="#character-properties" id="ref-for-character-properties-3">Character</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-7">Related</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-7">Related</a></p>
     <dd data-md="">
      <p><a class="css" data-link-type="property" href="#propdef-cuts" id="ref-for-propdef-cuts-6">cuts</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-15">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-15">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-17">property-name</a> = "x_bboxes"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-17">property-value</a> = 1*(4<a data-link-type="grammar" href="#grammardef-uint" id="ref-for-grammardef-uint-16">uint</a>)
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">x_bboxes</span> <span class="n">b1x0</span> <span class="n">b1y0</span> <span class="n">b1x1</span> <span class="n">b1y1</span> <span class="n">b2x0</span> <span class="n">b2y0</span> <span class="n">b2x1</span> <span class="n">b2y1</span> <span class="p">.</span><span class="p">.</span><span class="p">.</span>
 <span class="n">x_bboxes</span> <span class="mi">0</span> <span class="mi">0</span> <span class="mi">10</span> <span class="mi">10</span> <span class="mi">0</span> <span class="mi">10</span> <span class="mi">20</span> <span class="mi">20</span>
@@ -2939,21 +3056,27 @@ element, not of individual characters</p>
    </ul>
    <h3 class="heading settled" data-level="4.16" id="x_font"><span class="secno">4.16. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-x_font">x_font</dfn> property</span><a class="self-link" href="#x_font"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-16">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-16">Name</a></p>
     <dd data-md="">
      <p>x_font</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-16">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-16">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#font-properties" id="ref-for-font-properties-1">Font</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-8">Related</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-8">Related</a></p>
     <dd data-md="">
      <p><a class="css" data-link-type="property" href="#propdef-x_fsize" id="ref-for-propdef-x_fsize-3">x_fsize</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-16">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-16">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-18">property-name</a> = "x_font"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-18">property-value</a> = <a data-link-type="grammar" href="#grammardef-delimited-string" id="ref-for-grammardef-delimited-string-6">delimited-string</a>
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">x_font</span> <span class="s">"</span><span class="s">Comic Sans MS</span><span class="s">"</span>
 </pre>
@@ -2961,21 +3084,27 @@ element, not of individual characters</p>
    <p><a class="property" data-link-type="propdesc" href="#propdef-x_font" id="ref-for-propdef-x_font-3">x_font</a> is an OCR-engine specific font name (a string).</p>
    <h3 class="heading settled" data-level="4.17" id="x_fsize"><span class="secno">4.17. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-x_fsize">x_fsize</dfn> property</span><a class="self-link" href="#x_fsize"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-17">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-17">Name</a></p>
     <dd data-md="">
      <p>x_fsize</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-17">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-17">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#font-properties" id="ref-for-font-properties-2">Font</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-9">Related</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-9">Related</a></p>
     <dd data-md="">
      <p><a class="css" data-link-type="property" href="#propdef-x_font" id="ref-for-propdef-x_font-4">x_font</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-17">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-17">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-19">property-name</a> = "x_fsize"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-19">property-value</a> = <a data-link-type="grammar" href="#grammardef-uint" id="ref-for-grammardef-uint-17">uint</a>
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">x_fsize</span> <span class="mi">12</span>
 </pre>
@@ -2983,18 +3112,23 @@ element, not of individual characters</p>
    <p><a class="property" data-link-type="propdesc" href="#propdef-x_fsize" id="ref-for-propdef-x_fsize-4">x_fsize</a> is the OCR-engine specific font size (an unsigned integer).</p>
    <h3 class="heading settled" data-level="4.18" id="x_confs"><span class="secno">4.18. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-x_confs">x_confs</dfn> property</span><a class="self-link" href="#x_confs"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-18">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-18">Name</a></p>
     <dd data-md="">
      <p>x_confs</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-18">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-18">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#confidence-properties" id="ref-for-confidence-properties-2">Confidence</a>, <a data-link-type="dfn" href="#character-properties" id="ref-for-character-properties-4">Character</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-18">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-18">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-20">property-name</a> = "x_confs"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-20">property-value</a> = +<a data-link-type="grammar" href="#grammardef-float" id="ref-for-grammardef-float-4">float</a>
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">x_confs</span> <span class="mf">37.3</span> <span class="mf">51.23</span> <span class="mi">1</span> <span class="mi">100</span>
 </pre>
@@ -3012,21 +3146,27 @@ have them approximate posterior probabilities (expressed in %)</p>
    </ul>
    <h3 class="heading settled" data-level="4.19" id="x_scanner"><span class="secno">4.19. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-x_scanner">x_scanner</dfn> property</span><a class="self-link" href="#x_scanner"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-19">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-19">Name</a></p>
     <dd data-md="">
      <p>x_scanner</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-19">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-19">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#page-properties" id="ref-for-page-properties-6">Page</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-10">Related</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-10">Related</a></p>
     <dd data-md="">
      <p><a class="css" data-link-type="property" href="#propdef-scan_res" id="ref-for-propdef-scan_res-3">scan_res</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-19">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-19">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-21">property-name</a> = "x_scanner"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-21">property-value</a> = <a data-link-type="grammar" href="#grammardef-delimited-string" id="ref-for-grammardef-delimited-string-7">delimited-string</a>
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">scanner</span> <span class="s">"</span><span class="s">Canon Lide 220</span><span class="s">"</span>
 </pre>
@@ -3034,21 +3174,27 @@ have them approximate posterior probabilities (expressed in %)</p>
    <p>A representation of the scanner</p>
    <h3 class="heading settled" data-level="4.20" id="x_source"><span class="secno">4.20. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-x_source">x_source</dfn> property</span><a class="self-link" href="#x_source"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-20">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-20">Name</a></p>
     <dd data-md="">
      <p>x_source</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-20">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-20">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#page-properties" id="ref-for-page-properties-7">Page</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-11">Related</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#related-property" id="ref-for-related-property-11">Related</a></p>
     <dd data-md="">
      <p><a class="css" data-link-type="property" href="#propdef-image" id="ref-for-propdef-image-4">image</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-20">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-20">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-22">property-name</a> = "x_source"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-22">property-value</a> = 1*<a data-link-type="grammar" href="#grammardef-delimited-string" id="ref-for-grammardef-delimited-string-8">delimited-string</a>
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">x_source</span> <span class="s">"</span><span class="s">/gfs/cc/clean/012345678911</span><span class="s">"</span> <span class="s">"</span><span class="s">17</span><span class="s">"</span>
 <span class="n">x_source</span> <span class="s">"</span><span class="s">http://pageserver/012345678911&amp;page=17</span><span class="s">"</span>
@@ -3065,18 +3211,23 @@ additional strings or using URL parameters or fragments</p>
    </ul>
    <h3 class="heading settled" data-level="4.21" id="x_wconf"><span class="secno">4.21. </span><span class="content">The <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-x_wconf">x_wconf</dfn> property</span><a class="self-link" href="#x_wconf"></a></h3>
    <dl class="def">
-    <dt data-md=""><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-21">Name</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-name" id="ref-for-property-name-21">Name</a></p>
     <dd data-md="">
      <p>x_wconf</p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-21">Categories</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-categories" id="ref-for-property-categories-21">Categories</a></p>
     <dd data-md="">
      <p><a data-link-type="dfn" href="#confidence-properties" id="ref-for-confidence-properties-3">Confidence</a>, <a data-link-type="dfn" href="#inline-properties" id="ref-for-inline-properties-4">Inline</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-21">Grammar</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#property-grammar" id="ref-for-property-grammar-21">Grammar</a></p>
     <dd data-md="">
 <pre class="highlight"><a data-link-type="grammar" href="#grammardef-property-name" id="ref-for-grammardef-property-name-23">property-name</a> = "x_wconf"
 <a data-link-type="grammar" href="#grammardef-property-value" id="ref-for-grammardef-property-value-23">property-value</a> = <a data-link-type="grammar" href="#grammardef-float" id="ref-for-grammardef-float-5">float</a>
+
 </pre>
-    <dt data-md="">Example
+    <dt data-md="">
+     <p>Example</p>
     <dd data-md="">
 <pre class="highlight" style="display:block;padding: .5em"><span class="n">x_wconf</span> <span class="mf">97.23</span>
 </pre>
@@ -3219,27 +3370,32 @@ correctly process the hOCR information.</p>
    <p>The creator of the hOCR document can indicate the following information
 information using <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> tags in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element">head</a></code> section.</p>
    <dl>
-    <dt data-md=""><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-ocr-system">ocr-system</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-ocr-system">ocr-system</dfn></p>
     <dd data-md="">
      <p>Indicates software and version that generated the hOCR document</p>
     <dd data-md="">
      <p>Every hOCR document <em>must</em> have exactly one <a class="property" data-link-type="propdesc" href="#propdef-ocr-system" id="ref-for-propdef-ocr-system-1">ocr-system</a> metadata field</p>
-    <dt data-md=""><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-ocr-capabilities">ocr-capabilities</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-ocr-capabilities">ocr-capabilities</dfn></p>
     <dd data-md="">
      <p>Features consumers of the hOCR document can expect</p>
     <dd data-md="">
      <p>See <a href="#capabilities">§6.2 Capabilities</a> for possible values</p>
     <dd data-md="">
      <p>Every hOCR document <em>must</em> have exactly one <a class="property" data-link-type="propdesc" href="#propdef-ocr-capabilities" id="ref-for-propdef-ocr-capabilities-2">ocr-capabilities</a> metadata field</p>
-    <dt data-md=""><dfn class="css" data-dfn-type="property" data-export="" id="propdef-ocr-number-of-pages">ocr-number-of-pages<a class="self-link" href="#propdef-ocr-number-of-pages"></a></dfn>
+    <dt data-md="">
+     <p><dfn class="css" data-dfn-type="property" data-export="" id="propdef-ocr-number-of-pages">ocr-number-of-pages<a class="self-link" href="#propdef-ocr-number-of-pages"></a></dfn></p>
     <dd data-md="">
      <p>The number of <code><a data-link-type="element" href="#elementdef-ocr_page" id="ref-for-elementdef-ocr_page-6">ocr_page</a></code> in the document</p>
-    <dt data-md=""><dfn class="css" data-dfn-type="property" data-export="" id="propdef-ocr-langs">ocr-langs<a class="self-link" href="#propdef-ocr-langs"></a></dfn>
+    <dt data-md="">
+     <p><dfn class="css" data-dfn-type="property" data-export="" id="propdef-ocr-langs">ocr-langs<a class="self-link" href="#propdef-ocr-langs"></a></dfn></p>
     <dd data-md="">
      <p>Use <a href="https://www.loc.gov/standards/iso639-2/php/code_list.php">ISO 639-1</a> codes</p>
     <dd data-md="">
      <p>Value may be <code>unknown</code></p>
-    <dt data-md=""><dfn class="css" data-dfn-type="property" data-export="" id="propdef-ocr-scripts">ocr-scripts<a class="self-link" href="#propdef-ocr-scripts"></a></dfn>
+    <dt data-md="">
+     <p><dfn class="css" data-dfn-type="property" data-export="" id="propdef-ocr-scripts">ocr-scripts<a class="self-link" href="#propdef-ocr-scripts"></a></dfn></p>
     <dd data-md="">
      <p>Use <a href="http://www.unicode.org/iso15924/codelists.html">ISO 15924</a> letter codes</p>
     <dd data-md="">
@@ -3262,26 +3418,33 @@ corresponding element or attribute must not be present in the document.</p>
    <p>The capability to generate specific properties is given by the prefix <code>ocrp_...</code>;
 the important properties are:</p>
    <dl>
-    <dt data-md=""><dfn class="dfn-paneled css" data-dfn-for="ocr-capabilities" data-dfn-type="value" data-export="" id="valdef-ocr-capabilities-ocrp_lang">ocrp_lang</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled css" data-dfn-for="ocr-capabilities" data-dfn-type="value" data-export="" id="valdef-ocr-capabilities-ocrp_lang">ocrp_lang</dfn></p>
     <dd data-md="">
      <p>Capable of generating <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/dom.html#attr-lang">lang</a></code> attributes</p>
-    <dt data-md=""><dfn class="css" data-dfn-for="ocr-capabilities" data-dfn-type="value" data-export="" id="valdef-ocr-capabilities-ocrp_dir">ocrp_dir<a class="self-link" href="#valdef-ocr-capabilities-ocrp_dir"></a></dfn>
+    <dt data-md="">
+     <p><dfn class="css" data-dfn-for="ocr-capabilities" data-dfn-type="value" data-export="" id="valdef-ocr-capabilities-ocrp_dir">ocrp_dir<a class="self-link" href="#valdef-ocr-capabilities-ocrp_dir"></a></dfn></p>
     <dd data-md="">
      <p>Capable of generating <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute">dir</a></code> attributes</p>
-    <dt data-md=""><dfn class="dfn-paneled css" data-dfn-for="ocr-capabilities" data-dfn-type="value" data-export="" id="valdef-ocr-capabilities-ocrp_poly">ocrp_poly</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled css" data-dfn-for="ocr-capabilities" data-dfn-type="value" data-export="" id="valdef-ocr-capabilities-ocrp_poly">ocrp_poly</dfn></p>
     <dd data-md="">
      <p>Capable of generating <a href="#poly">polygonal bounds</a></p>
-    <dt data-md=""><dfn class="dfn-paneled css" data-dfn-for="ocr-capabilities" data-dfn-type="value" data-export="" id="valdef-ocr-capabilities-ocrp_font">ocrp_font</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled css" data-dfn-for="ocr-capabilities" data-dfn-type="value" data-export="" id="valdef-ocr-capabilities-ocrp_font">ocrp_font</dfn></p>
     <dd data-md="">
      <p>Capable of generating font information (standard font information)</p>
-    <dt data-md=""><dfn class="css" data-dfn-for="ocr-capabilities" data-dfn-type="value" data-export="" id="valdef-ocr-capabilities-ocrp_nlp">ocrp_nlp<a class="self-link" href="#valdef-ocr-capabilities-ocrp_nlp"></a></dfn>
+    <dt data-md="">
+     <p><dfn class="css" data-dfn-for="ocr-capabilities" data-dfn-type="value" data-export="" id="valdef-ocr-capabilities-ocrp_nlp">ocrp_nlp<a class="self-link" href="#valdef-ocr-capabilities-ocrp_nlp"></a></dfn></p>
     <dd data-md="">
      <p>Capable of generating <a class="property" data-link-type="propdesc" href="#propdef-nlp" id="ref-for-propdef-nlp-4">nlp confidences</a></p>
-    <dt data-md=""><code>ocr_embeddedformat_&lt;formatname></code>
+    <dt data-md="">
+     <p><code>ocr_embeddedformat_&lt;formatname></code></p>
     <dd data-md="">
      <p>The capability to generate other specific embedded formats is given by the
 prefix <code>ocr_embeddedformat_&lt;formatname></code>.</p>
-    <dt data-md=""><code>ocr_&lt;tag>_unordered</code>
+    <dt data-md="">
+     <p><code>ocr_&lt;tag>_unordered</code></p>
     <dd data-md="">
      <p>If an OCR engine represents a particular tag but cannot determine reading
 order for that tag, it must must specify a capability of <code>ocr_&lt;tag>_unordered</code>.</p>
@@ -3320,7 +3483,7 @@ document classes:</p>
       <li data-md="">
        <p><code><a data-link-type="element" href="#elementdef-ocr_page" id="ref-for-elementdef-ocr_page-7">ocr_page</a></code></p>
       <li data-md="">
-       <p><code><a data-link-type="element" href="#elementdef-ocrx_block" id="ref-for-elementdef-ocrx_block-7">ocrx_block</a></code>, <code><a data-link-type="element" href="#elementdef-ocrx_line" id="ref-for-elementdef-ocrx_line-5">ocrx_line</a></code>, <code><a data-link-type="element" href="#elementdef-ocrx_word" id="ref-for-elementdef-ocrx_word-2">ocrx_word</a></code></p>
+       <p><code><a data-link-type="element" href="#elementdef-ocrx_block" id="ref-for-elementdef-ocrx_block-7">ocrx_block</a></code>, <code><a data-link-type="element" href="#elementdef-ocrx_line" id="ref-for-elementdef-ocrx_line-7">ocrx_line</a></code>, <code><a data-link-type="element" href="#elementdef-ocrx_word" id="ref-for-elementdef-ocrx_word-2">ocrx_word</a></code></p>
       <li data-md="">
        <p><a class="css" data-link-type="maybe" href="#valdef-ocr-capabilities-ocrp_lang" id="ref-for-valdef-ocr-capabilities-ocrp_lang-1">ocrp_lang</a></p>
       <li data-md="">
@@ -3361,19 +3524,24 @@ modifications.</p>
 suitable for different kinds of processing and use. The formats have the
 following intents:</p>
    <dl>
-    <dt data-md=""><a data-link-type="dfn" href="#html_none" id="ref-for-html_none-1">html_none</a> (see <a href="#format-none">§6.4.1 HTML without logical markup</a>)
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#html_none" id="ref-for-html_none-1">html_none</a> (see <a href="#format-none">§6.4.1 HTML without logical markup</a>)</p>
     <dd data-md="">
      <p>Straightforward equivalent of Goodoc or <a data-link-type="biblio" href="#biblio-xdoc">[XDOC]</a></p>
-    <dt data-md=""><a data-link-type="dfn" href="#html_simple" id="ref-for-html_simple-1">html_simple</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#html_simple" id="ref-for-html_simple-1">html_simple</a></p>
     <dd data-md="">
      <p>Target format for convenient on-line viewing and intermediate format for indexing</p>
-    <dt data-md=""><a data-link-type="dfn" href="#html_xytable_absolute" id="ref-for-html_xytable_absolute-1">html_xytable_absolute</a>, <a data-link-type="dfn" href="#html_xytable_relative" id="ref-for-html_xytable_relative-1">html_xytable_relative</a>
+    <dt data-md="">
+     <p><a data-link-type="dfn" href="#html_xytable_absolute" id="ref-for-html_xytable_absolute-1">html_xytable_absolute</a>, <a data-link-type="dfn" href="#html_xytable_relative" id="ref-for-html_xytable_relative-1">html_xytable_relative</a></p>
     <dd data-md="">
      <p>Target format for layout-preserving on-screen document viewing</p>
-    <dt data-md="">Formats defined in <a href="#format-ocr">§6.4.3 HTML produced by OCR engines</a>
+    <dt data-md="">
+     <p>Formats defined in <a href="#format-ocr">§6.4.3 HTML produced by OCR engines</a></p>
     <dd data-md="">
      <p>Straightforward recording of commercial OCR system output</p>
-    <dt data-md="">Formats defined in <a href="#format-absolute">§6.4.4 HTML with absolute positioning</a>
+    <dt data-md="">
+     <p>Formats defined in <a href="#format-absolute">§6.4.4 HTML with absolute positioning</a></p>
     <dd data-md="">
      <p>Target format for services like Google’s View as HTML</p>
    </dl>
@@ -3420,33 +3588,42 @@ recommendations above, and only uses the following tags:</p>
 must follow the template <code>html_ocr_&lt;engine></code>.</p>
    <p>Examples of possible values are:</p>
    <dl>
-    <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="html_ocr_unknown">html_ocr_unknown<a class="self-link" href="#html_ocr_unknown"></a></dfn>
+    <dt data-md="">
+     <p><dfn data-dfn-type="dfn" data-noexport="" id="html_ocr_unknown">html_ocr_unknown<a class="self-link" href="#html_ocr_unknown"></a></dfn></p>
     <dd data-md="">
      <p>The HTML was generated by some OCR engine, but it’s unknown which one</p>
-    <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="html_ocr_finereader_8">html_ocr_finereader_8<a class="self-link" href="#html_ocr_finereader_8"></a></dfn>
-    <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="html_ocr_textbridge_11">html_ocr_textbridge_11<a class="self-link" href="#html_ocr_textbridge_11"></a></dfn>
+    <dt data-md="">
+     <p><dfn data-dfn-type="dfn" data-noexport="" id="html_ocr_finereader_8">html_ocr_finereader_8<a class="self-link" href="#html_ocr_finereader_8"></a></dfn></p>
+    <dt data-md="">
+     <p><dfn data-dfn-type="dfn" data-noexport="" id="html_ocr_textbridge_11">html_ocr_textbridge_11<a class="self-link" href="#html_ocr_textbridge_11"></a></dfn></p>
    </dl>
    <h4 class="heading settled" data-level="6.4.4" id="format-absolute"><span class="secno">6.4.4. </span><span class="content">HTML with absolute positioning</span><a class="self-link" href="#format-absolute"></a></h4>
    <dl>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="html_absolute">html_absolute</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="html_absolute">html_absolute</dfn></p>
     <dd data-md="">
      <p>The HTML represents absolute positioning of elements on each page.</p>
    </dl>
    <p>Possible subformats are:</p>
    <dl>
-    <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="html_absolute_cols">html_absolute_cols<a class="self-link" href="#html_absolute_cols"></a></dfn>
+    <dt data-md="">
+     <p><dfn data-dfn-type="dfn" data-noexport="" id="html_absolute_cols">html_absolute_cols<a class="self-link" href="#html_absolute_cols"></a></dfn></p>
     <dd data-md="">
      <p>absolute positioning of cols</p>
-    <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="html_absolute_pars">html_absolute_pars<a class="self-link" href="#html_absolute_pars"></a></dfn>
+    <dt data-md="">
+     <p><dfn data-dfn-type="dfn" data-noexport="" id="html_absolute_pars">html_absolute_pars<a class="self-link" href="#html_absolute_pars"></a></dfn></p>
     <dd data-md="">
      <p>absolute positioning of paragraphs</p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="html_absolute_lines">html_absolute_lines</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="html_absolute_lines">html_absolute_lines</dfn></p>
     <dd data-md="">
      <p>absolute positioning of lines</p>
-    <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="html_absolute_words">html_absolute_words<a class="self-link" href="#html_absolute_words"></a></dfn>
+    <dt data-md="">
+     <p><dfn data-dfn-type="dfn" data-noexport="" id="html_absolute_words">html_absolute_words<a class="self-link" href="#html_absolute_words"></a></dfn></p>
     <dd data-md="">
      <p>absolute positioning of words</p>
-    <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="html_absolute_chars">html_absolute_chars<a class="self-link" href="#html_absolute_chars"></a></dfn>
+    <dt data-md="">
+     <p><dfn data-dfn-type="dfn" data-noexport="" id="html_absolute_chars">html_absolute_chars<a class="self-link" href="#html_absolute_chars"></a></dfn></p>
     <dd data-md="">
      <p>absolute positioning of characters</p>
    </dl>
@@ -3455,7 +3632,8 @@ files</a> feature of Google Search uses <a data-link-type="dfn" href="#html_abso
 reasonable choice for approximating the appearance of the original document.</p>
    <h4 class="heading settled" data-level="6.4.5" id="format-table"><span class="secno">6.4.5. </span><span class="content">HTML as table</span><a class="self-link" href="#format-table"></a></h4>
    <dl>
-    <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="html_xytable">html_xytable<a class="self-link" href="#html_xytable"></a></dfn>
+    <dt data-md="">
+     <p><dfn data-dfn-type="dfn" data-noexport="" id="html_xytable">html_xytable<a class="self-link" href="#html_xytable"></a></dfn></p>
     <dd data-md="">
      <p>The HTML is a table that gives the XY-cut layout segmentation structure of
 the page in tabular form.</p>
@@ -3467,10 +3645,12 @@ reading order.</p>
    </dl>
    <p>Possible subformats are:</p>
    <dl>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="html_xytable_absolute">html_xytable_absolute</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="html_xytable_absolute">html_xytable_absolute</dfn></p>
     <dd data-md="">
      <p>The <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/tables.html#the-table-element">table</a></code> structure must represent the absolute size of the original page element.</p>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="html_xytable_relative">html_xytable_relative</dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="html_xytable_relative">html_xytable_relative</dfn></p>
     <dd data-md="">
      <p>Table element sizes are expressed relative (percentages).</p>
    </dl>
@@ -3484,14 +3664,18 @@ say, a scanned and ocr’ed article uses the same conventions for logical markup
 tags that an equivalent article actually written in LaTeX and actually
 converted to HTML would have used.</p>
    <dl>
-    <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="html_latex2html">html_latex2html</dfn>
-    <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="html_msword">html_msword<a class="self-link" href="#html_msword"></a></dfn>
+    <dt data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="html_latex2html">html_latex2html</dfn></p>
+    <dt data-md="">
+     <p><dfn data-dfn-type="dfn" data-noexport="" id="html_msword">html_msword<a class="self-link" href="#html_msword"></a></dfn></p>
     <dd data-md="">
      <p>HTML mapping generated by “Save As HTML”</p>
-    <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="html_ooffice">html_ooffice<a class="self-link" href="#html_ooffice"></a></dfn>
+    <dt data-md="">
+     <p><dfn data-dfn-type="dfn" data-noexport="" id="html_ooffice">html_ooffice<a class="self-link" href="#html_ooffice"></a></dfn></p>
     <dd data-md="">
      <p>HTML mapping generated by “Save As HTML”</p>
-    <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="html_docbook_xsl">html_docbook_xsl<a class="self-link" href="#html_docbook_xsl"></a></dfn>
+    <dt data-md="">
+     <p><dfn data-dfn-type="dfn" data-noexport="" id="html_docbook_xsl">html_docbook_xsl<a class="self-link" href="#html_docbook_xsl"></a></dfn></p>
     <dd data-md="">
      <p>HTML mapping generated by official XSL style sheets</p>
    </dl>
@@ -3515,7 +3699,7 @@ converted to HTML would have used.</p>
      <li data-md="">
       <p>was produced by Tesseract v3.03</p>
      <li data-md="">
-      <p>will provide <code><a data-link-type="element" href="#elementdef-ocr_page" id="ref-for-elementdef-ocr_page-10">ocr_page</a></code> and <code><a data-link-type="element" href="#elementdef-ocr_line" id="ref-for-elementdef-ocr_line-8">ocr_line</a></code> elements with <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/dom.html#attr-lang">lang</a></code> attribute</p>
+      <p>will provide <code><a data-link-type="element" href="#elementdef-ocr_page" id="ref-for-elementdef-ocr_page-10">ocr_page</a></code> and <code><a data-link-type="element" href="#elementdef-ocr_line" id="ref-for-elementdef-ocr_line-10">ocr_line</a></code> elements with <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/dom.html#attr-lang">lang</a></code> attribute</p>
      <li data-md="">
       <p>contains text written in the Afar, Latin or Zulu languages</p>
      <li data-md="">
@@ -3549,7 +3733,7 @@ they’re actually pretty easy to manipulate. Here are some examples:</p>
 <span class="k">def</span> <span class="nf">get_text</span><span class="p">(</span><span class="n">node</span><span class="p">)</span><span class="p">:</span>
     <span class="n">textnodes</span> <span class="o">=</span> <span class="n">node</span><span class="o">.</span><span class="n">xpathEval</span><span class="p">(</span><span class="s2">"</span><span class="s2">.//text()</span><span class="s2">"</span><span class="p">)</span>
     <span class="n">s</span> <span class="o">=</span> <span class="n">string</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="p">[</span><span class="n">node</span><span class="o">.</span><span class="n">getContent</span><span class="p">(</span><span class="p">)</span> <span class="k">for</span> <span class="n">node</span> <span class="ow">in</span> <span class="n">textnodes</span><span class="p">]</span><span class="p">)</span>
-    <span class="k">return</span> <span class="n">re</span><span class="o">.</span><span class="n">sub</span><span class="p">(</span>r<span class="s1">'</span><span class="s1">\</span><span class="s1">s+</span><span class="s1">'</span><span class="p">,</span><span class="s1">'</span><span class="s1"> </span><span class="s1">'</span><span class="p">,</span><span class="n">s</span><span class="p">)</span>
+    <span class="k">return</span> <span class="n">re</span><span class="o">.</span><span class="n">sub</span><span class="p">(</span><span class="s1">r'</span><span class="s1">\</span><span class="s1">s+</span><span class="s1">'</span><span class="p">,</span><span class="s1">'</span><span class="s1"> </span><span class="s1">'</span><span class="p">,</span><span class="n">s</span><span class="p">)</span>
 
 <span class="c1"># a function for extracting the bbox property from a node</span>
 <span class="c1"># note that the title= attribute on a node with an ocr_ class must</span>
@@ -3557,7 +3741,7 @@ they’re actually pretty easy to manipulate. Here are some examples:</p>
 
 <span class="k">def</span> <span class="nf">get_bbox</span><span class="p">(</span><span class="n">node</span><span class="p">)</span><span class="p">:</span>
     <span class="n">data</span> <span class="o">=</span> <span class="n">node</span><span class="o">.</span><span class="n">prop</span><span class="p">(</span><span class="s1">'</span><span class="s1">title</span><span class="s1">'</span><span class="p">)</span>
-    <span class="n">bboxre</span> <span class="o">=</span> <span class="n">re</span><span class="o">.</span><span class="n">compile</span><span class="p">(</span>r<span class="s1">'</span><span class="s1">\</span><span class="s1">bbbox</span><span class="s1">\</span><span class="s1">s+(</span><span class="s1">\</span><span class="s1">d+)</span><span class="s1">\</span><span class="s1">s+(</span><span class="s1">\</span><span class="s1">d+)</span><span class="s1">\</span><span class="s1">s+(</span><span class="s1">\</span><span class="s1">d+)</span><span class="s1">\</span><span class="s1">s+(</span><span class="s1">\</span><span class="s1">d+)</span><span class="s1">'</span><span class="p">)</span>
+    <span class="n">bboxre</span> <span class="o">=</span> <span class="n">re</span><span class="o">.</span><span class="n">compile</span><span class="p">(</span><span class="s1">r'</span><span class="s1">\</span><span class="s1">bbbox</span><span class="s1">\</span><span class="s1">s+(</span><span class="s1">\</span><span class="s1">d+)</span><span class="s1">\</span><span class="s1">s+(</span><span class="s1">\</span><span class="s1">d+)</span><span class="s1">\</span><span class="s1">s+(</span><span class="s1">\</span><span class="s1">d+)</span><span class="s1">\</span><span class="s1">s+(</span><span class="s1">\</span><span class="s1">d+)</span><span class="s1">'</span><span class="p">)</span>
     <span class="k">return</span> <span class="p">[</span>int<span class="p">(</span><span class="n">x</span><span class="p">)</span> <span class="k">for</span> <span class="n">x</span> <span class="ow">in</span> <span class="n">bboxre</span><span class="o">.</span><span class="n">search</span><span class="p">(</span><span class="n">data</span><span class="p">)</span><span class="o">.</span><span class="n">groups</span><span class="p">(</span><span class="p">)</span><span class="p">]</span>
 
 <span class="c1"># this extracts all the bounding boxes and the text they contain</span>
@@ -3574,21 +3758,30 @@ within the same HTML file without interfering with one another.</p>
    <p>In accordance to <a data-link-type="biblio" href="#biblio-rfc4289">[RFC4289]</a></p>
    <p class="issue" id="issue-19855aac"><a class="self-link" href="#issue-19855aac"></a> <a href="https://github.com/kba/hocr-spec/issues/27">correct MIME type for hOCR?</a></p>
    <dl>
-    <dt data-md="">MIME media type name
+    <dt data-md="">
+     <p>MIME media type name</p>
     <dd data-md="">
      <p><code>text</code></p>
-    <dt data-md="">MIME subtype name:
+    <dt data-md="">
+     <p>MIME subtype name:</p>
     <dd data-md="">
      <p><code>vnd.hocr+html</code></p>
-    <dt data-md="">Required parameters:
-    <dt data-md="">Optional parameters:
-    <dt data-md="">Encoding considerations:
+    <dt data-md="">
+     <p>Required parameters:</p>
+    <dt data-md="">
+     <p>Optional parameters:</p>
+    <dt data-md="">
+     <p>Encoding considerations:</p>
     <dd data-md="">
      <p>hOCR documents should be encoded as UTF-8</p>
-    <dt data-md="">Security considerations:
-    <dt data-md="">Interoperability considerations:
-    <dt data-md="">Applications which use this media type:
-    <dt data-md="">File extension(s):
+    <dt data-md="">
+     <p>Security considerations:</p>
+    <dt data-md="">
+     <p>Interoperability considerations:</p>
+    <dt data-md="">
+     <p>Applications which use this media type:</p>
+    <dt data-md="">
+     <p>File extension(s):</p>
     <dd data-md="">
      <p><code>*.html</code>, <code>*.hocr</code></p>
 <script>
@@ -3612,7 +3805,7 @@ for (var span of document.querySelectorAll(".toc span:not([class])")) {
             except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a> </p>
    <p> Examples in this specification are introduced with the words “for example”
             or are set apart from the normative text with <code>class="example"</code>, like this: </p>
-   <div class="example" id="example-example"><a class="self-link" href="#example-example"></a> This is an example of an informative example. </div>
+   <div class="example" id="example-ae2b6bc0"><a class="self-link" href="#example-ae2b6bc0"></a> This is an example of an informative example. </div>
    <p> Informative notes begin with the word “Note”
             and are set apart from the normative text with <code>class="note"</code>, like this: </p>
    <p class="note" role="note"> Note, this is an informative note. </p>
@@ -3946,7 +4139,7 @@ for (var span of document.querySelectorAll(".toc span:not([class])")) {
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-html">[HTML]
-   <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-html401">[HTML401]
    <dd>Dave Raggett; Arnaud Le Hors; Ian Jacobs. <a href="https://www.w3.org/TR/html401">HTML 4.01 Specification</a>. 24 December 1999. REC. URL: <a href="https://www.w3.org/TR/html401">https://www.w3.org/TR/html401</a>
    <dt id="biblio-rfc2119">[RFC2119]
@@ -3978,7 +4171,6 @@ properties for floating elements; properties need to be defined for this.<a href
    <div class="issue"> <a href="https://github.com/kba/hocr-spec/issues/51">&lt;https://github.com/kba/hocr-spec/issues/51></a><a href="#issue-d41d8cd9"> ↵ </a></div>
    <div class="issue"> Define <span>ocrx_cinfo</span><a href="#issue-d9f7da0d"> ↵ </a></div>
    <div class="issue"> <a href="https://github.com/kba/hocr-spec/issues/28">ocr_carea vs ocrx_block</a><a href="#issue-66c198d9"> ↵ </a></div>
-   <div class="issue"> <a href="https://github.com/kba/hocr-spec/issues/19">ocr_line vs ocrx_line</a><a href="#issue-8ef34561"> ↵ </a></div>
    <div class="issue"> How to handle hyphens? <a href="https://github.com/kba/hocr-spec/issues/7">&lt;https://github.com/kba/hocr-spec/issues/7></a><a href="#issue-b90972d0"> ↵ </a></div>
    <div class="issue"> Non Linear Hyphens <a href="https://github.com/altoxml/schema/issues/41">&lt;https://github.com/altoxml/schema/issues/41></a><a href="#issue-3040ab4b"> ↵ </a></div>
    <div class="issue"> <a href="https://github.com/kba/hocr-spec/issues/9">Delete x_cost</a><a href="#issue-b35297dd"> ↵ </a></div>
@@ -4475,10 +4667,10 @@ properties for floating elements; properties need to be defined for this.<a href
    <b><a href="#elementdef-ocr_line">#elementdef-ocr_line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-ocr_line-1">3.1.4. ocr_line</a> <a href="#ref-for-elementdef-ocr_line-2">(2)</a> <a href="#ref-for-elementdef-ocr_line-3">(3)</a>
-    <li><a href="#ref-for-elementdef-ocr_line-4">3.5.2. ocrx_line</a> <a href="#ref-for-elementdef-ocr_line-5">(2)</a>
-    <li><a href="#ref-for-elementdef-ocr_line-6">4. The properties of hOCR</a>
-    <li><a href="#ref-for-elementdef-ocr_line-7">4.5. The hardbreak property</a>
-    <li><a href="#ref-for-elementdef-ocr_line-8">6.5. Example</a>
+    <li><a href="#ref-for-elementdef-ocr_line-4">3.5.2. ocrx_line</a> <a href="#ref-for-elementdef-ocr_line-5">(2)</a> <a href="#ref-for-elementdef-ocr_line-6">(3)</a> <a href="#ref-for-elementdef-ocr_line-7">(4)</a>
+    <li><a href="#ref-for-elementdef-ocr_line-8">4. The properties of hOCR</a>
+    <li><a href="#ref-for-elementdef-ocr_line-9">4.5. The hardbreak property</a>
+    <li><a href="#ref-for-elementdef-ocr_line-10">6.5. Example</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="elementdef-ocr_separator">
@@ -4712,9 +4904,9 @@ properties for floating elements; properties need to be defined for this.<a href
    <b><a href="#elementdef-ocrx_line">#elementdef-ocrx_line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-ocrx_line-1">3.4.4. Unspecified inline content: ocr_cinfo</a>
-    <li><a href="#ref-for-elementdef-ocrx_line-2">3.5.2. ocrx_line</a> <a href="#ref-for-elementdef-ocrx_line-3">(2)</a>
-    <li><a href="#ref-for-elementdef-ocrx_line-4">4. The properties of hOCR</a>
-    <li><a href="#ref-for-elementdef-ocrx_line-5">6.3. Profiles - Restricting hOCR markup</a>
+    <li><a href="#ref-for-elementdef-ocrx_line-2">3.5.2. ocrx_line</a> <a href="#ref-for-elementdef-ocrx_line-3">(2)</a> <a href="#ref-for-elementdef-ocrx_line-4">(3)</a> <a href="#ref-for-elementdef-ocrx_line-5">(4)</a>
+    <li><a href="#ref-for-elementdef-ocrx_line-6">4. The properties of hOCR</a>
+    <li><a href="#ref-for-elementdef-ocrx_line-7">6.3. Profiles - Restricting hOCR markup</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="elementdef-ocrx_word">

--- a/1.2/spec.md
+++ b/1.2/spec.md
@@ -528,11 +528,26 @@ Generators should attempt to ensure the following properties:
 
 <pre class="include">path: 1.2/include/defs/ocrx_line</pre>
 
-Issue: [ocr_line vs ocrx_line](https://github.com/kba/hocr-spec/issues/19)
-
   * any kind of "line" returned by an OCR system that differs from the standard <{ocr_line}> above
   * might be some kind of "logical" line
   * an <{ocrx_line}> should correspond as closely as possible to an <{ocr_line}>
+
+<div class="note">
+
+<{ocrx_line}> is engine-specific line markup. It exists for those cases where
+your OCR engine outputs text lines that don't correspond to "normal" text lines.
+
+The most common case is if you apply an engine that is not capable of column
+segmentation to a multi-column document and you want to prevent subsequent
+processing stages from assuming that the text lines it gets contain text in
+reading order.
+
+Basically, if you use <{ocrx_line}> instead of <{ocr_line}>, you're
+(intentionally) breaking most subsequent processing, since most OCR output
+processing will look for <{ocr_line}> tags (and assume they are in reading
+order).
+
+</div>
 
 ### <dfn element>ocrx_word</dfn> ### {#sec-ocrx_word}
 


### PR DESCRIPTION
This adds @tmbdev's note on the intention of `ocrx_line` from #39, i.e. use `ocrx_line` only if lines aren't guaranteed to be in reading order / engine doesn't support columns, so should clear up #19.