### PR TITLE
Explicitly specify behavior of baseline property in the presence of textangle property

### DIFF
--- a/1.2/spec.md
+++ b/1.2/spec.md
@@ -587,8 +587,25 @@ This property applies primarily to textlines.
 The baseline is described by a polynomial of order `n` with the coefficients
 `pn ...  p0` with `n = 1` for a linear (i.e. straight) line.
 
-The polynomial is in the coordinate system of the line, with the bottom left of
-the bounding box as the origin.
+The polynomial is in coordinate system which depends on the `textangle` value
+that is effective for the element. The coordinate system is defined as follows:
+
+  * if `textangle` property is not present or has value in ranges `[315, 360]` or
+    `[0, 45)`, then the origin is the bottom left of the bounding box. The x-axis
+    and the y-axis are the same as the x-axis and the y-axis of the document image
+    respectively.
+
+  * if `textangle` property has value in range `[45, 135)` then the origin is the
+    bottom right of the bounding box. The x-axis is the opposite as the y-axis
+    of the document image, y-axis is the same as the x-axis of the document image.
+
+  * if `textangle` property has value in range `[135, 225)` then the origin is the
+    top right of the bounding box. The x-axis and the y-axis are the opposite of
+    the x-axis and the y-axis of the document image respectively.
+
+  * if `textangle` property has value in range `[225, 315)` then the origin is the
+    top left of the bounding box. The x-axis is the same as the y-axis
+    of the document image, y-axis is the opposite of the x-axis of the document image.
 
 <div class="example">
 

--- a/1.2/spec.md
+++ b/1.2/spec.md
@@ -844,7 +844,7 @@ The <dfn property>textangle</dfn> property {#textangle}
 
 <pre class="include">path: include/defs/textangle</pre>
 
-The angle in degrees by which textual content has been rotate relative to the
+The angle in degrees by which textual content has been rotated relative to the
 rest of the page (if not present, the angle is assumed to be zero); rotations
 are counter-clockwise, so an angle of 90 degrees is vertical text running from
 bottom to top in Latin script; note that this is different from reading order,


### PR DESCRIPTION
This PR fixes an error in the specification related in interaction between `baseline` and `textangle` properties. 

Currently the `baseline` property is underspecified: the polyline refers to "coordinate system of the line" which is not defined anywhere else in the document. This makes it unclear how baseline should be specified when `textangle` is non-zero.

The interpretation that `textangle` should be ignored would result in error in the specification because completely vertical text would have slope angle equal to positive or negative infinity which can not be represented by the current grammar.

Therefore, `textangle` should be taken into account. However, it's not clear how it should affect baseline because the specification does not constrain `textangle` to any specific angle.

This issue is fixed by explicitly specifying what coordinate system would be used for the baseline polynomial in all possible values of `textangle` property.

Due to this issue tesseract-ocr currently does not output baseline for non-horizontal text at all. Fixing the specification will hopefully allow to output baseline information in all cases.
